### PR TITLE
Support tagging Network Interfaces

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -290,11 +290,11 @@ variable "launch_template_version" {
 
 variable "resources_to_tag" {
   type        = list(string)
-  description = "List of auto-launched resource types to tag. Valid types are \"instance\", \"volume\", \"elastic-gpu\", \"spot-instances-request\"."
+  description = "List of auto-launched resource types to tag. Valid types are \"instance\", \"volume\", \"elastic-gpu\", \"spot-instances-request\", \"network-interface\"."
   default     = []
   validation {
     condition = (
-      length(compact([for r in var.resources_to_tag : r if !contains(["instance", "volume", "elastic-gpu", "spot-instances-request"], r)])) == 0
+      length(compact([for r in var.resources_to_tag : r if !contains(["instance", "volume", "elastic-gpu", "spot-instances-request", "network-interface"], r)])) == 0
     )
     error_message = "Invalid resource type in `resources_to_tag`. Valid types are \"instance\", \"volume\", \"elastic-gpu\", \"spot-instances-request\"."
   }


### PR DESCRIPTION
## what
Add support for tagging Network Interfaces with var.resources_to_tag

## why
According to [LaunchTemplateTagSpecificationRequest](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_LaunchTemplateTagSpecificationRequest.html) Documentation, Network Interfaces are now supported for tagging on creation.

## references
* https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_LaunchTemplateTagSpecificationRequest.html

